### PR TITLE
Add libGL and libm to link libraries (avoid --as-needed problems)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ aux_source_directory(source SRC)
 aux_source_directory(source/libtess TESS_SRC)
 aux_source_directory(libnurbs/*/ NURBS_SRC)
 add_library(GLU SHARED ${SRC} ${TESS_SRC} ${NURBS_SRC})
+target_link_libraries(GLU GL m)
 
 if(CMAKE_SHARED_LIBRARY_SUFFIX MATCHES ".so")
     set_target_properties(GLU PROPERTIES SUFFIX ".so.1")


### PR DESCRIPTION
Without this fix, the configure script of GL-117 game in Gentoo Linux
just can't find GLU:

```
configure:7271: armv7a-hardfloat-linux-gnueabi-gcc -o conftest -O2 -pipe \
    -march=armv7-a -mtune=cortex-a8 -g  -I/usr/include -I/usr/include \
    -Wl,-O1 -Wl,--as-needed -lm -lGL -lGLU -lglut conftest.c -lGLU \
    -L/usr/X11R6/lib -L/usr/lib -L/usr/lib -lGL >&5
/usr/lib/libGLU.so: undefined reference to `glPopClientAttrib'
/usr/lib/libGLU.so: undefined reference to `glVertexPointer'
/usr/lib/libGLU.so: undefined reference to `glDrawArrays'
/usr/lib/libGLU.so: undefined reference to `glTexImage2D'
/usr/lib/libGLU.so: undefined reference to `glEnableClientState'
/usr/lib/libGLU.so: undefined reference to `glOrtho'
/usr/lib/libGLU.so: undefined reference to `glPixelStorei'
/usr/lib/libGLU.so: undefined reference to `glDisableClientState'
/usr/lib/libGLU.so: undefined reference to `glPushClientAttrib'
/usr/lib/libGLU.so: undefined reference to `glNormalPointer'
/usr/lib/libGLU.so: undefined reference to `sin'
/usr/lib/libGLU.so: undefined reference to `glScalef'
/usr/lib/libGLU.so: undefined reference to `glMultMatrixf'
/usr/lib/libGLU.so: undefined reference to `glTexCoordPointer'
/usr/lib/libGLU.so: undefined reference to `cos'
/usr/lib/libGLU.so: undefined reference to `glTranslatef'
/usr/lib/libGLU.so: undefined reference to `sqrt'
/usr/lib/libGLU.so: undefined reference to `glGetIntegerv'
/usr/lib/libGLU.so: undefined reference to `floor'
/usr/lib/libGLU.so: undefined reference to `glNormal3f'
collect2: error: ld returned 1 exit status
configure:7277: $? = 1
```

The use of -Wl,--as-needed option is too blame, which makes library
dependencies handling a bit more strict:
    http://www.gentoo.org/proj/en/qa/asneeded.xml
